### PR TITLE
Use greentext format when formatting blockquotes

### DIFF
--- a/app/assets/javascripts/app/helpers/text_formatter.js
+++ b/app/assets/javascripts/app/helpers/text_formatter.js
@@ -19,6 +19,15 @@ $(function() {
   textFormatter.markdownify = function markdownify(text){
     var converter = Markdown.getSanitizingConverter();
 
+    converter.hooks.chain("preConversion", function(text) {
+        return text
+        // Move lines immediatly following a quote another line down
+            .replace(/(>[^\r\n]*\r?\n)([^>])/g, "$1\r\n$2")
+        // Replace ">..." with ">\\>...<br>" and let markdown do the rest
+            .replace(/^>([^\r\n]*)(\r?\n|$)/gm, ">\\>$1<br>\r\n")
+        ;
+    });
+
     // punycode non-ascii chars in urls
     converter.hooks.chain("preConversion", function(text) {
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -229,6 +229,12 @@ ul.as-selections
       :bottom 10px
 
 .stream_element
+
+  blockquote
+    :color #789922
+    :font-style normal
+    :margin-left 0
+
   a.author
     :font-weight bold
     :unicode-bidi bidi-override

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -79,6 +79,14 @@ h3 {
     font: {
       weight: normal; }; }
   padding: 0 !important; 
+
+  blockquote {
+    color: #789922;
+    font-style: normal;
+    margin-left: 0;
+    border-left: none;
+    padding-left: 0;
+  }
 }
 .shield{
   padding: 10px;

--- a/lib/diaspora/markdownify/html.rb
+++ b/lib/diaspora/markdownify/html.rb
@@ -8,6 +8,13 @@ module Diaspora
         auto_link(link, :link => :urls, :html => { :target => "_blank" })
       end
 
+      def block_quote(text)
+        Rails.logger.info(text.dump)
+
+        ret = text.gsub(/(<p>|\n)(?=[^$])/, "&gt;")
+        "<blockquote>" + ret  + "</blockquote>"
+      end
+
     end
   end
 end


### PR DESCRIPTION
An implementation of greentext that cooperates with markdown.

The hook in `text_formatter.js` edits markdown before it is rendered. (Adds a `\>` after `>`)

On the mobile version the markdown is rendered on the backend and the hook in `html.rb` edits the HTML instead (adding `&gt;` after line breaks)

There's also some CSS that makes it show the same way as on 4chan.
