### PR TITLE
Show greentext everywhere

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -229,12 +229,6 @@ ul.as-selections
       :bottom 10px
 
 .stream_element
-
-  blockquote
-    :color #789922
-    :font-style normal
-    :margin-left 0
-
   a.author
     :font-weight bold
     :unicode-bidi bidi-override

--- a/app/assets/stylesheets/default.css
+++ b/app/assets/stylesheets/default.css
@@ -12,4 +12,6 @@
 *= require vendor/autoSuggest
 *= require entypo-fonts
 *= require entypo
+
+*= require outerheaven
 */

--- a/app/assets/stylesheets/outerheaven.css.scss
+++ b/app/assets/stylesheets/outerheaven.css.scss
@@ -1,0 +1,7 @@
+blockquote {
+  color: #789922;
+  font-style: normal;
+  margin-left: 0;
+  border-left: none;
+  padding-left: 0;
+}


### PR DESCRIPTION
If any static content or something uses blockquotes this may break something. Other than that it shows up everywhere now.
